### PR TITLE
Update OVRManager.cs

### DIFF
--- a/Assets/OVR/Scripts/OVRManager.cs
+++ b/Assets/OVR/Scripts/OVRManager.cs
@@ -318,7 +318,8 @@ public class OVRManager : MonoBehaviour
 		}
 
 		instance = this;
-
+		
+		
 #if !UNITY_ANDROID || UNITY_EDITOR
 		var netVersion = new System.Version(Ovr.Hmd.OVR_VERSION_STRING);
 		var ovrVersion = new System.Version(Ovr.Hmd.GetVersionString());
@@ -370,7 +371,7 @@ public class OVRManager : MonoBehaviour
 			display = new OVRDisplay();
 		if (tracker == null)
 			tracker = new OVRTracker();
-
+			tracker.isEnabled = usingPositionTracking = usePositionTracking;
 		if (resetTrackerOnLoad)
 			display.RecenterPose();
 


### PR DESCRIPTION
if usePositionTracking boolean was false on OVRManager, tracking was not initial disabled. This was due to tracking.enabled only being called on Update if usePositionTracking and usingPositionTracking differ, and usingPositionTracking is initially set to false.

I've now explicitly set tracking enable value when tracking is constructed.